### PR TITLE
Add baseline configuration & Sirepo/MAD-X updates

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.10"]
         pylon-version: ["5.2.0.13457-deb0_amd64"]
       fail-fast: false
     env:

--- a/startup/10-devices.py
+++ b/startup/10-devices.py
@@ -6,6 +6,7 @@ from contextlib import ContextDecorator
 
 from atfdb import atfdb
 from atfdb.ophyd import ATFSignalNoConn, ReadOnlyException, open_close_conn
+from bluesky import SupplementalData
 from ophyd import Component as Cpt
 from ophyd import Device, Signal
 from ophyd.sim import NullStatus
@@ -212,3 +213,7 @@ GQ10 = channel_dict["GQ10"]["ophyd"]
 GQ11 = channel_dict["GQ11"]["ophyd"]
 GQ12 = channel_dict["GQ12"]["ophyd"]
 HeNe1 = channel_dict["HeNe1"]["ophyd"]
+
+sd = SupplementalData()
+RE.preprocessors.append(sd)
+sd.baseline.extend([GQ10, GQ11, GQ12])

--- a/startup/10-devices.py
+++ b/startup/10-devices.py
@@ -197,16 +197,16 @@ fg3 = FrameGrabber(name="fg3")
 
 
 for el_id in [
-        "GQ10",
-        "GQ11",
-        "GQ12",
-        "GT10V",
-        "GT9V",
-        "HQ1",
-        "HT2V",
-        "HeNe1",
-        "TK1H",
-    ]:
+    "GQ10",
+    "GQ11",
+    "GQ12",
+    "GT10V",
+    "GT9V",
+    "HQ1",
+    "HT2V",
+    "HeNe1",
+    "TK1H",
+]:
     el = channel_dict[el_id]
     channel_dict[el_id]["ophyd"] = ATFSignal(
         name=f"{el_id}_{el['name']}",  # ophyd API

--- a/startup/10-devices.py
+++ b/startup/10-devices.py
@@ -48,7 +48,7 @@ PS_H_line = {
     "HT1V": "DARL2",
     "HT2H": "DARL3",
     "HT2V": "DARL4",
-    "HQ1": "DARL149",
+    "HQ1": "DARL149",  # 'ihq1' in Sirepo
     "HQ2": "DARL150",
     "HQ3": "DARL151",
     "HT3H": "DARL9",
@@ -196,7 +196,17 @@ class FrameGrabber(Device):
 fg3 = FrameGrabber(name="fg3")
 
 
-for el_id in ["TK1H", "GT9V", "GT10V", "GQ10", "GQ11", "GQ12", "HeNe1"]:
+for el_id in [
+        "GQ10",
+        "GQ11",
+        "GQ12",
+        "GT10V",
+        "GT9V",
+        "HQ1",
+        "HT2V",
+        "HeNe1",
+        "TK1H",
+    ]:
     el = channel_dict[el_id]
     channel_dict[el_id]["ophyd"] = ATFSignal(
         name=f"{el_id}_{el['name']}",  # ophyd API
@@ -206,13 +216,15 @@ for el_id in ["TK1H", "GT9V", "GT10V", "GQ10", "GQ11", "GQ12", "HeNe1"]:
         timeout=3.0 if el_id == "TK1H" else 2.0,
     )
 
-TK1H = channel_dict["TK1H"]["ophyd"]
-GT9V = channel_dict["GT9V"]["ophyd"]
-GT10V = channel_dict["GT10V"]["ophyd"]
 GQ10 = channel_dict["GQ10"]["ophyd"]
 GQ11 = channel_dict["GQ11"]["ophyd"]
 GQ12 = channel_dict["GQ12"]["ophyd"]
+GT10V = channel_dict["GT10V"]["ophyd"]
+GT9V = channel_dict["GT9V"]["ophyd"]
+HQ1 = channel_dict["HQ1"]["ophyd"]
+HT2V = channel_dict["HT2V"]["ophyd"]
 HeNe1 = channel_dict["HeNe1"]["ophyd"]
+TK1H = channel_dict["TK1H"]["ophyd"]
 
 sd = SupplementalData()
 RE.preprocessors.append(sd)

--- a/startup/20-madx.py
+++ b/startup/20-madx.py
@@ -23,9 +23,11 @@ else:
     connection = SirepoBluesky(ATF_SIREPO_URL)
     data, schema = connection.auth("madx", "00000002")  # BL2_TDC example
 
-    classes, objects = create_classes(connection.data,
-                                      connection=connection,
-                                      extra_model_fields=["rpnVariables", "commands", "elements"])
+    classes, objects = create_classes(
+        connection.data,
+        connection=connection,
+        extra_model_fields=["rpnVariables", "commands", "elements"],
+    )
     globals().update(**objects)
 
     madx_flyer = MADXFlyer(
@@ -33,7 +35,6 @@ else:
         root_dir=root_dir,
         report="elementAnimation250-20",
     )
-
 
     def madx_plan(parameter="ihq1", value=2.0):
         """A bluesky plan to use MAD-X simulation package within Sirepo (via sirepo-bluesky lib).

--- a/startup/20-madx.py
+++ b/startup/20-madx.py
@@ -21,9 +21,11 @@ else:
 
     print(f"Using Sirepo at {ATF_SIREPO_URL}")
     connection = SirepoBluesky(ATF_SIREPO_URL)
-    data, schema = connection.auth("madx", "00000002")
+    data, schema = connection.auth("madx", "00000002")  # BL2_TDC example
 
-    classes, objects = create_classes(connection.data, connection=connection)
+    classes, objects = create_classes(connection.data,
+                                      connection=connection,
+                                      extra_model_fields=["rpnVariables", "commands", "elements"])
     globals().update(**objects)
 
     madx_flyer = MADXFlyer(

--- a/startup/20-madx.py
+++ b/startup/20-madx.py
@@ -53,5 +53,5 @@ else:
             plt.plot(tbl['madx_flyer_S'], tbl['madx_flyer_BETY'])
 
         """
-        yield from bps.mv(objects_var[parameter].value, value)
+        yield from bps.mv(objects[parameter].value, value)
         return (yield from bp.fly([madx_flyer]))

--- a/startup/20-madx.py
+++ b/startup/20-madx.py
@@ -24,7 +24,6 @@ else:
     data, schema = connection.auth("madx", "00000002")  # BL2_TDC example
 
     classes, objects = create_classes(
-        connection.data,
         connection=connection,
         extra_model_fields=["rpnVariables", "commands", "elements"],
     )

--- a/startup/20-madx.py
+++ b/startup/20-madx.py
@@ -32,18 +32,24 @@ else:
         report="elementAnimation250-20",
     )
 
-# RE(bp.fly([madx_flyer]))
-#
-# hdr = db["2c8504e4-8ac9-4e56-ab42-da5e3cb9b4e0"]
-# hdr.table(stream_name="madx_flyer", fill=True)
-#
-# def madx_plan():
-#     yield from bps.mv(fq1.k1, "ifq1/5.4444e-3/hr")
-#     yield from bp.fly([madx_flyer])
-#
-# RE(madx_plan())
-#
-# hdr2 = db["a3ed4aea-068e-4b15-85f7-3abdcf5cccc2"]
-#
-# hdr.table(stream_name="madx_flyer", fill=True).loc[21]
-# hdr2.table(stream_name="madx_flyer", fill=True).loc[21]
+
+    def madx_plan(parameter="ihq1", value=2.0):
+        """A bluesky plan to use MAD-X simulation package within Sirepo (via sirepo-bluesky lib).
+
+        Run:
+
+            uid, = RE(bp.fly([madx_flyer]))
+
+        Data access:
+
+            hdr = db[uid]
+            tbl = hdr.table(stream_name="madx_flyer", fill=True)
+
+        Plotting:
+
+            plt.plot(tbl['madx_flyer_S'], tbl['madx_flyer_BETX'])
+            plt.plot(tbl['madx_flyer_S'], tbl['madx_flyer_BETY'])
+
+        """
+        yield from bps.mv(objects_var[parameter].value, value)
+        return (yield from bp.fly([madx_flyer]))

--- a/startup/20-madx.py
+++ b/startup/20-madx.py
@@ -38,7 +38,7 @@ else:
 
         Run:
 
-            uid, = RE(bp.fly([madx_flyer]))
+            uid, = RE(madx_plan())
 
         Data access:
 


### PR DESCRIPTION
### Updates:
- more ophyd devices for ATF hardware
- add a few devices for baseline readings/stream. Based on [nslsii](https://github.com/NSLS-II/nslsii/blob/765eaa72967b4733a5e058ed0b3204a223482922/nslsii/__init__.py#L145-L151)
- add `madx_plan` for bluesky scans with sirepo-bluesky (currently uses the PR branch https://github.com/NSLS-II/sirepo-bluesky/pull/84)

### Comparison with Sirepo:
![Screen Shot 2022-10-12 at 17 50 43](https://user-images.githubusercontent.com/13209176/195455540-986e1c4e-1ec2-4810-b970-fc958597807f.png)
