### PR TITLE
CI: enable end-to-end testing

### DIFF
--- a/.ci/drop-in.py
+++ b/.ci/drop-in.py
@@ -5,3 +5,18 @@ GQ11.read()
 GQ12.read()
 
 fg3.read()
+
+uid, = RE(bp.fly([madx_flyer]))
+
+hdr = db[uid]
+print(hdr.table(stream_name="madx_flyer", fill=True))
+
+def madx_plan():
+    yield from bps.mv(fq1.k1, "ifq1/5.4444e-3/hr")
+    yield from bp.fly([madx_flyer])
+
+uid2, = RE(madx_plan())
+
+hdr2 = db[uid2]
+
+print(hdr2.table(stream_name="madx_flyer", fill=True))

--- a/.ci/drop-in.py
+++ b/.ci/drop-in.py
@@ -1,15 +1,17 @@
-print(GT9V.read())
-print(GT10V.read())
-print(GQ10.read())
-print(GQ11.read())
-print(GQ12.read())
+from pprint import pprint
 
-print(fg3.read())
+pprint(GT9V.read())
+pprint(GT10V.read())
+pprint(GQ10.read())
+pprint(GQ11.read())
+pprint(GQ12.read())
+
+pprint(fg3.read())
 
 uid, = RE(bp.fly([madx_flyer]))
 
 hdr = db[uid]
-print(hdr.table(stream_name="madx_flyer", fill=True))
+print(hdr.table(stream_name="madx_flyer", fill=True).T)
 
 def madx_plan():
     yield from bps.mv(fq1.k1, "ifq1/5.4444e-3/hr")
@@ -19,4 +21,4 @@ uid2, = RE(madx_plan())
 
 hdr2 = db[uid2]
 
-print(hdr2.table(stream_name="madx_flyer", fill=True))
+print(hdr2.table(stream_name="madx_flyer", fill=True).T)

--- a/.ci/drop-in.py
+++ b/.ci/drop-in.py
@@ -1,0 +1,7 @@
+GT9V.read()
+GT10V.read()
+GQ10.read()
+GQ11.read()
+GQ12.read()
+
+fg3.read()

--- a/.ci/drop-in.py
+++ b/.ci/drop-in.py
@@ -1,10 +1,10 @@
-GT9V.read()
-GT10V.read()
-GQ10.read()
-GQ11.read()
-GQ12.read()
+print(GT9V.read())
+print(GT10V.read())
+print(GQ10.read())
+print(GQ11.read())
+print(GQ12.read())
 
-fg3.read()
+print(fg3.read())
 
 uid, = RE(bp.fly([madx_flyer]))
 

--- a/.ci/srv.py
+++ b/.ci/srv.py
@@ -29,7 +29,7 @@ def server_program(seed=0):
     rng = default_rng(seed)
 
     while True:
-        # receive data stream. it won't accept data packet greater than 1024 bytes
+        # receive data stream. it won't accept data packet greater than `recv_buffer_size` bytes
         data = conn.recv(recv_buffer_size).decode()
         if not data:
             # if data is not received break

--- a/.ci/srv.py
+++ b/.ci/srv.py
@@ -7,7 +7,7 @@ from numpy.random import default_rng
 def server_program(seed=0):
     # get the hostname
     host = os.getenv("ATF_SOCKET_HOST", "localhost")
-    port = os.getenv("ATF_SOCKET_PORT", 5000)  # initiate port no above 1024
+    port = int(os.getenv("ATF_SOCKET_PORT", 5000))  # initiate port no above 1024
 
     server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # look closely. The bind() function takes tuple as argument

--- a/.ci/srv.py
+++ b/.ci/srv.py
@@ -1,12 +1,13 @@
 import os
 import socket
+
 from numpy.random import default_rng
 
 
 def server_program(seed=0):
     # get the hostname
     host = os.getenv("ATF_SOCKET_HOST", "localhost")
-    port = os.getenv("ATF_SOCKET_PORT", 5000)   # initiate port no above 1024
+    port = os.getenv("ATF_SOCKET_PORT", 5000)  # initiate port no above 1024
 
     server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # look closely. The bind() function takes tuple as argument
@@ -42,5 +43,5 @@ def server_program(seed=0):
     conn.close()  # close the connection
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     server_program()

--- a/.ci/srv.py
+++ b/.ci/srv.py
@@ -9,6 +9,9 @@ def server_program(seed=0):
     host = os.getenv("ATF_SOCKET_HOST", "localhost")
     port = int(os.getenv("ATF_SOCKET_PORT", 5000))  # initiate port no above 1024
 
+    recv_buffer_size = int(os.getenv(ATF_DB_RECEIVE_BUFFER_SIZE, 5120))
+    send_buffer_size = int(os.getenv(ATF_DB_SEND_BUFFER_SIZE, 5120))
+
     server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # look closely. The bind() function takes tuple as argument
     server_socket.bind((host, port))  # bind host address and port together
@@ -24,7 +27,7 @@ def server_program(seed=0):
 
     while True:
         # receive data stream. it won't accept data packet greater than 1024 bytes
-        data = conn.recv(1024).decode()
+        data = conn.recv(recv_buffer_size).decode()
         if not data:
             # if data is not received break
             break

--- a/.ci/srv.py
+++ b/.ci/srv.py
@@ -9,8 +9,8 @@ def server_program(seed=0):
     host = os.getenv("ATF_SOCKET_HOST", "localhost")
     port = int(os.getenv("ATF_SOCKET_PORT", 5000))  # initiate port no above 1024
 
-    recv_buffer_size = int(os.getenv(ATF_DB_RECEIVE_BUFFER_SIZE, 5120))
-    send_buffer_size = int(os.getenv(ATF_DB_SEND_BUFFER_SIZE, 5120))
+    recv_buffer_size = int(os.getenv("ATF_DB_RECEIVE_BUFFER_SIZE", 5120))
+    send_buffer_size = int(os.getenv("ATF_DB_SEND_BUFFER_SIZE", 5120))  # noqa F841
 
     server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     # look closely. The bind() function takes tuple as argument

--- a/.ci/srv.py
+++ b/.ci/srv.py
@@ -1,0 +1,46 @@
+import os
+import socket
+from numpy.random import default_rng
+
+
+def server_program(seed=0):
+    # get the hostname
+    host = os.getenv("ATF_SOCKET_HOST", "localhost")
+    port = os.getenv("ATF_SOCKET_PORT", 5000)   # initiate port no above 1024
+
+    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # look closely. The bind() function takes tuple as argument
+    server_socket.bind((host, port))  # bind host address and port together
+
+    # configure how many client the server can listen simultaneously
+    server_socket.listen(2)
+    conn, address = server_socket.accept()  # accept new connection
+    print("Connection from: " + str(address))
+    data = "greeting"
+    conn.send(data.encode())  # send data to the client
+
+    rng = default_rng(seed)
+
+    while True:
+        # receive data stream. it won't accept data packet greater than 1024 bytes
+        data = conn.recv(1024).decode()
+        if not data:
+            # if data is not received break
+            break
+        data = str(data)
+        print(f"from connected user: {data}")
+        if data.startswith("GETCHIDX"):
+            reply = f"{rng.integers(0, 100)}"
+            print(f"reply to client: {reply}")
+            conn.send(reply.encode())  # send data to the client
+        elif data.startswith(("GETRS", "GETDS")):
+            reply = f"{rng.random()}"
+            print(f"reply to client: {reply}")
+            conn.send(reply.encode())  # send data to the client
+        else:
+            print(f"{data = }")
+    conn.close()  # close the connection
+
+
+if __name__ == '__main__':
+    server_program()

--- a/.ci/srv.py
+++ b/.ci/srv.py
@@ -1,3 +1,6 @@
+"""
+Based on https://www.digitalocean.com/community/tutorials/python-socket-programming-server-client.
+"""
 import os
 import socket
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Get Sirepo running
         run: |
-          set -vxuo pipefail
+          set -vxeuo pipefail
           git clone https://github.com/NSLS-II/sirepo-bluesky.git
           cd sirepo-bluesky/
           . scripts/start_sirepo.sh -d
@@ -105,12 +105,18 @@ jobs:
 
       - name: Start fake socket server
         run: |
-          set -vxuo pipefail
+          set -vxeuo pipefail
           nohup python .ci/srv.py > /tmp/socket.log 2>&1 &
+
+      - name: Prepare databroker config
+        run: |
+          set -vxeuo pipefail
+          mkdir -v -p $HOME/.config/databroker/
+          cp -v configs/databroker/local.yml $HOME/.config/databroker/
 
       - name: Test the code
         run: |
-          set -vxuo pipefail
+          set -vxeuo pipefail
           # This is what IPython does internally to load the startup files:
           command="
           import os
@@ -136,5 +142,5 @@ jobs:
 
       - name: Check socket server logs
         run: |
-          set -vxuo pipefail
+          set -vxeuo pipefail
           cat /tmp/socket.log

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -138,14 +138,20 @@ jobs:
 
           ipython --profile=test -c "$command"
           status=$?
-          docker ps -a
-          echo "Sirepo docker container id: ${SIREPO_DOCKER_CONTAINER_ID}"
-          docker logs ${SIREPO_DOCKER_CONTAINER_ID}
-          if [ $status -gt 0 ]; then
-              exit $status
-          fi
+          export ATF_PROFILE_TEST_STATUS="${status}"
+          echo "ATF_PROFILE_TEST_STATUS=${ATF_PROFILE_TEST_STATUS}" >> $GITHUB_ENV
 
       - name: Check socket server logs
         run: |
           set -vxeuo pipefail
           cat /tmp/socket.log
+
+      - name: Check Sirepo server logs
+        run: |
+          set -vxeuo pipefail
+          docker ps -a
+          echo "Sirepo docker container id: ${SIREPO_DOCKER_CONTAINER_ID}"
+          docker logs ${SIREPO_DOCKER_CONTAINER_ID}
+          if [ ${ATF_PROFILE_TEST_STATUS} -gt 0 ]; then
+              exit ${ATF_PROFILE_TEST_STATUS}
+          fi

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,6 +35,9 @@ jobs:
           export ATF_SOCKET_PORT=5000
           echo "ATF_SOCKET_PORT=${ATF_SOCKET_PORT}" >> $GITHUB_ENV
 
+          export ATF_SIREPO_URL="http://localhost:8000"
+          echo "ATF_SIREPO_URL=${ATF_SIREPO_URL}" >> $GITHUB_ENV
+
           export PYLON_CAMEMU=2
           echo "PYLON_CAMEMU=${PYLON_CAMEMU}" >> $GITHUB_ENV
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -70,7 +70,9 @@ jobs:
           # line 1: GSETTINGS_SCHEMA_DIR_CONDA_BACKUP: unbound variable
           set -vxeo pipefail
           conda env list
-          mamba install -c conda-forge -y numpy matplotlib ipython ophyd bluesky databroker sirepo-bluesky
+          # mamba install -c conda-forge -y numpy matplotlib ipython ophyd bluesky databroker sirepo-bluesky
+          pip install numpy matplotlib ipython ophyd bluesky databroker sirepo-bluesky
+          mamba install -c conda-forge -y srwpy shadow3
           # pip install -v pypylon
           pip list
           conda list
@@ -80,7 +82,7 @@ jobs:
           set -vxuo pipefail
           git clone https://github.com/NSLS-II/sirepo-bluesky.git
           cd sirepo-bluesky/
-          bash scripts/start_sirepo -d
+          bash scripts/start_sirepo.sh -d
           sleep 10
 
       - name: Start fake socket server

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,6 +26,15 @@ jobs:
           export REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}  # just the repo, as opposed to org/repo
           echo "REPOSITORY_NAME=${REPOSITORY_NAME}" >> $GITHUB_ENV
 
+          export ATF_OPEN_CONN_ONCE="yes"
+          echo "ATF_OPEN_CONN_ONCE=${ATF_OPEN_CONN_ONCE}" >> $GITHUB_ENV
+
+          export ATF_SOCKET_HOST="localhost"
+          echo "ATF_SOCKET_HOST=${ATF_SOCKET_HOST}" >> $GITHUB_ENV
+
+          export ATF_SOCKET_PORT=5000
+          echo "ATF_SOCKET_PORT=${ATF_SOCKET_PORT}" >> $GITHUB_ENV
+
           export PYLON_CAMEMU=2
           echo "PYLON_CAMEMU=${PYLON_CAMEMU}" >> $GITHUB_ENV
 
@@ -61,13 +70,44 @@ jobs:
           # line 1: GSETTINGS_SCHEMA_DIR_CONDA_BACKUP: unbound variable
           set -vxeo pipefail
           conda env list
-          mamba install -c conda-forge -y numpy matplotlib
-          pip install -v pypylon
+          mamba install -c conda-forge -y numpy matplotlib ipython ophyd bluesky databroker sirepo-bluesky
+          # pip install -v pypylon
           pip list
           conda list
+
+      - name: Get Sirepo running
+        run: |
+          set -vxuo pipefail
+          git clone https://github.com/NSLS-II/sirepo-bluesky.git
+          cd sirepo-bluesky/
+          bash scripts/start_sirepo -d
+          sleep 10
+
+      - name: Start fake socket server
+        run: |
+          set -vxuo pipefail
+          nohup python .ci/srv.py > /tmp/socket.log 2>&1 &
 
       - name: Test the code
         run: |
           set -vxuo pipefail
-          wget ${{ secrets.PYLON_GRAB_SCRIPT }}/pylon_grab.py -O pylon_grab.py
-          python pylon_grab.py
+          # This is what IPython does internally to load the startup files:
+          command="${connection_timeout}
+          import os
+          import glob
+          ip = get_ipython()
+          startup_files = sorted(glob.glob(os.path.join(os.getcwd(), 'startup/*.py')))
+          if not startup_files:
+              raise SystemExit(f'Cannot find any startup files in {os.getcwd()}')
+          for f in startup_files:
+              if not os.path.isfile(f):
+                  raise FileNotFoundError(f'File {f} cannot be found.')
+              print(f'Executing {f} in CI')
+              ip.parent._exec_file(f)"
+
+          ipython --profile=test -c "$command"
+
+      - name: Check socket server logs
+        run: |
+          set -vxuo pipefail
+          cat /tmp/socket.log

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -47,12 +47,12 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v3
 
-      - name: Install Pylon .deb package
-        run: |
-          # For reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html.
-          set -vxeuo pipefail
-          wget --progress=dot:mega ${{ secrets.PYLON_DOWNLOAD_URL_BASE }}/pylon_${{ matrix.pylon-version }}.deb -O pylon.deb
-          sudo dpkg -i pylon.deb
+      # - name: Install Pylon .deb package
+      #   run: |
+      #     # For reference: https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html.
+      #     set -vxeuo pipefail
+      #     wget --progress=dot:mega ${{ secrets.PYLON_DOWNLOAD_URL_BASE }}/pylon_${{ matrix.pylon-version }}.deb -O pylon.deb
+      #     sudo dpkg -i pylon.deb
 
       - name: Set up Python ${{ matrix.python-version }} with conda
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   run_tests:
-    name: Test pylon camera
+    name: Test IPython startup files
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -77,13 +77,31 @@ jobs:
           pip list
           conda list
 
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.6.0
+
       - name: Get Sirepo running
         run: |
           set -vxuo pipefail
           git clone https://github.com/NSLS-II/sirepo-bluesky.git
           cd sirepo-bluesky/
-          bash scripts/start_sirepo.sh -d
+          . scripts/start_sirepo.sh -d
+          export SIREPO_DOCKER_CONTAINER_ID
+          echo "SIREPO_DOCKER_CONTAINER_ID=${SIREPO_DOCKER_CONTAINER_ID}" >> $GITHUB_ENV
+
+      - name: Check Sirepo state
+        run: |
+          set -vxeuo pipefail
+          # Sleeping to allow sirepo time to start up
           sleep 10
+          docker images
+          docker ps -a
+          container=$(docker ps -q -f id=${SIREPO_DOCKER_CONTAINER_ID})
+          docker logs ${SIREPO_DOCKER_CONTAINER_ID}
+          if [ -z "${container}" ]; then
+              echo "Container ID ${SIREPO_DOCKER_CONTAINER_ID} is not running. Exiting."
+              exit 1
+          fi
 
       - name: Start fake socket server
         run: |
@@ -94,7 +112,7 @@ jobs:
         run: |
           set -vxuo pipefail
           # This is what IPython does internally to load the startup files:
-          command="${connection_timeout}
+          command="
           import os
           import glob
           ip = get_ipython()
@@ -108,6 +126,13 @@ jobs:
               ip.parent._exec_file(f)"
 
           ipython --profile=test -c "$command"
+          status=$?
+          docker ps -a
+          echo "Sirepo docker container id: ${SIREPO_DOCKER_CONTAINER_ID}"
+          docker logs ${SIREPO_DOCKER_CONTAINER_ID}
+          if [ $status -gt 0 ]; then
+              exit $status
+          fi
 
       - name: Check socket server logs
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -126,6 +126,8 @@ jobs:
           import glob
           ip = get_ipython()
           startup_files = sorted(glob.glob(os.path.join(os.getcwd(), 'startup/*.py')))
+          if os.path.isfile('.ci/drop-in.py'):
+              startup_files.append('.ci/drop-in.py')
           if not startup_files:
               raise SystemExit(f'Cannot find any startup files in {os.getcwd()}')
           for f in startup_files:

--- a/startup/20-madx.py
+++ b/startup/20-madx.py
@@ -19,7 +19,7 @@ if ATF_SIREPO_URL in (None, ""):
 else:
     print(f"Using Sirepo at {ATF_SIREPO_URL}")
     connection = SirepoBluesky(ATF_SIREPO_URL)
-    data, schema = connection.auth("madx", "00000001")
+    data, schema = connection.auth("madx", "00000002")
 
     classes, objects = create_classes(connection.data,
                                       connection=connection)


### PR DESCRIPTION
This GHA implementation uses ideas from https://github.com/NSLS-II/profile-collection-ci/blob/main/.azure-templates/run-tests.yml to perform automated testing of the IPython startup files.

A "fake" socket server script is to facilitate testing of the socket-based ophyd objects.

We probably need to avoid using `try..except` in the `startup/lib/atf_db_py3x.py` library to make sure we get a proper failure if something does not work as expected (no connection, or socket server failure).

Successful CI run: https://github.com/mrakitin/profile_atf/actions/runs/3691821066/jobs/6250158939.